### PR TITLE
Fixes for body data operatorId handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,14 +122,10 @@ The parameters used in the URL must annotated with the @SwaggerParameter annotat
 * **dataType** - The data type of the parameter
      * *STRING*
      * *INTEGER*
-     * *DATE*
+     * *LONG* 
      * *BOOLEAN*
-     * *FLOAT*
-     * *DOUBLE*
-     * *BYTE*
+     * *DATE*
      * *DATETIME*
-
-**Note:** At the moment not all *dataType*s and *paramType*s are supported. But feel free to fix that.
 
 ## Documentation support
 

--- a/src/main/java/com/roamsys/swagger/SwaggerAPIServlet.java
+++ b/src/main/java/com/roamsys/swagger/SwaggerAPIServlet.java
@@ -20,7 +20,6 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -151,8 +150,12 @@ public class SwaggerAPIServlet extends HttpServlet {
                                             arguments[i] = request.getInputStream();
                                             break;
 
+                                        case HEADER:
+                                            arguments[i] = convertParamToArgument(paramData.getDataType(),request.getHeader(paramData.getName()));
+                                            break;
+
                                         default:
-                                            arguments[i] = convertParamToArgument(paramData.getDataType(), IOUtils.toString(request.getInputStream(), StandardCharsets.UTF_8));
+                                            throw new IllegalArgumentException("Handling for parameter type \"" + paramData.getParamType().name() + "\" not yet implemented.");
                                     }
                                 } catch (final ParseException ex) {
                                     config.getExceptionHandler().handleException(response, HttpServletResponse.SC_BAD_REQUEST, "Invalid value for parameter " + paramData.getName(), ex);

--- a/src/main/java/com/roamsys/swagger/annotations/SwaggerParameter.java
+++ b/src/main/java/com/roamsys/swagger/annotations/SwaggerParameter.java
@@ -41,17 +41,12 @@ public @interface SwaggerParameter {
      * Enum constants for parameter date types
      */
     public enum DataType {
-        DATA("data"),
         STRING("string"),
         INTEGER("integer"),
-        DATE("date"),
-        DATETIME("dateTime"),
-        BOOLEAN("boolean"),
         LONG("long"),
-        FLOAT("float"),
-        DOUBLE("double"),
-        BYTE("byte"),
-        FILE("file");
+        BOOLEAN("boolean"),
+        DATE("date"),
+        DATETIME("dateTime");
 
         private final String name;
 

--- a/src/main/java/com/roamsys/swagger/documentation/ApiSpecBuilder.java
+++ b/src/main/java/com/roamsys/swagger/documentation/ApiSpecBuilder.java
@@ -141,7 +141,7 @@ public class ApiSpecBuilder {
     private OperationApiSpec createOperatorSpec(final String modelName, final SwaggerModel modelAnnotation, final SwaggerApi apiAnnotation, final List<SwaggerParameter> parameterAnnotations) {
         final OperationApiSpec operationSpec = new OperationApiSpec();
         operationSpec.description = apiAnnotation.description().isEmpty() ? apiAnnotation.notes() : String.format("\n%s\n*Notes: %s*", apiAnnotation.description(), apiAnnotation.notes());
-        operationSpec.operationId = modelName + cleanupPath(apiAnnotation.path());
+        operationSpec.operationId = String.format("%s-%s-%s", apiAnnotation.method().toString(), modelName, cleanupPath(apiAnnotation.path()));
         operationSpec.tags = Collections.singletonList(modelName);
         operationSpec.produces = Collections.singletonList("application/" + modelAnnotation.format());
         operationSpec.summary = apiAnnotation.summary();
@@ -165,18 +165,20 @@ public class ApiSpecBuilder {
         parameterSpec.required = parameterAnnotation.required();
         parameterSpec.description = parameterAnnotation.description();
         parameterSpec.in = parameterAnnotation.paramType().toString();
-        switch (parameterAnnotation.dataType()) {
-            case DATA:
-                parameterSpec.schema = DEFAULT_OBJECT_SCHEMA;
-                break;
-            case DATE:
-            case DATETIME:
-                // Date is not a known type in OpenAPI/JSON
-                parameterSpec.type = SwaggerParameter.DataType.STRING.toString();
-                break;
-            default:
-                parameterSpec.type = parameterAnnotation.dataType().toString();
-                break;
+        if (parameterAnnotation.paramType() == SwaggerParameter.ParamType.BODY) {
+            parameterSpec.schema = DEFAULT_OBJECT_SCHEMA;
+        } else {
+            switch (parameterAnnotation.dataType()) {
+                case DATE:
+                case DATETIME:
+                    // Date is not a known type in OpenAPI/JSON
+                    parameterSpec.type = SwaggerParameter.DataType.STRING.toString();
+                    parameterSpec.format = parameterAnnotation.dataType() == SwaggerParameter.DataType.DATETIME ? "date-time" : "date";
+                    break;
+                default:
+                    parameterSpec.type = parameterAnnotation.dataType().toString();
+                    break;
+            }
         }
         return parameterSpec;
     }

--- a/src/main/java/com/roamsys/swagger/documentation/ParameterApiSpec.java
+++ b/src/main/java/com/roamsys/swagger/documentation/ParameterApiSpec.java
@@ -11,7 +11,7 @@ import java.util.Map;
 public class ParameterApiSpec extends AbstractApiSpecPart {
 
     @Expose
-    String name, in;
+    String name, in, format;
 
     @Expose
     boolean required;

--- a/src/test/resources/swagger.json
+++ b/src/test/resources/swagger.json
@@ -18,7 +18,7 @@
     "/testAPI.json/test": {
       "get": {
         "summary": "",
-        "operationId": "testAPItest",
+        "operationId": "get-testAPI-test",
         "tags": [
           "testAPI"
         ],


### PR DESCRIPTION
Fixes:
* Proper handling for `ParamType.BODY`
* Make `operatorId` unique by adding HTTP method name
* Additional format 'date'/'data-time' for D`ataType.DATE/DATETIME`
* General (execution) support for `ParamType.HEADER`
* Removal of all non-supported `ParamTypes`