### PR TITLE
Fix URL decoding of path parameters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.roamsys.opensource</groupId>
     <artifactId>swaggerapi</artifactId>
     <packaging>jar</packaging>
-    <version>5.0.0-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
     <organization>
         <name>ROAMSYS S.A.</name>
         <url>http://www.roamsys.com</url>


### PR DESCRIPTION
Use of `HttpServletRequest.getPathInfo()` instead of `HttpServletRequest.getContextPath()` to get URL decoded value. 
See [Oracle Javadoc](https://docs.oracle.com/javaee/6/api/javax/servlet/http/HttpServletRequest.html#getPathInfo()) for details