### PR TITLE
Support for port and protocol/schemes in API host

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.roamsys.opensource</groupId>
     <artifactId>swaggerapi</artifactId>
     <packaging>jar</packaging>
-    <version>7.0.0-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
     <organization>
         <name>ROAMSYS S.A.</name>
         <url>http://www.roamsys.com</url>

--- a/src/main/java/com/roamsys/swagger/SwaggerAPIConfig.java
+++ b/src/main/java/com/roamsys/swagger/SwaggerAPIConfig.java
@@ -12,6 +12,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -153,10 +154,15 @@ public class SwaggerAPIConfig {
      * Sets the URL serving the API. This field is important for completing the OpenAPI specification.
      * Declarations on the server providing the APIs themselves, it is not a requirement.
      *
-     * @param basePath The value should be in the format of a URL.
+     * @param apiUrl The API URL
      */
     public void setURL(final URL apiUrl) {
-        apiSpecBuilder.setHost(apiUrl.getHost());
+        apiSpecBuilder.setSchemes(Collections.singletonList(apiUrl.getProtocol()));
+        if (apiUrl.getPort() != -1) {
+            apiSpecBuilder.setHost(String.format("%s:%d", apiUrl.getHost(), apiUrl.getPort()));
+        } else {
+            apiSpecBuilder.setHost(apiUrl.getHost());
+        }
         apiSpecBuilder.setBasePath(apiUrl.getPath());
     }
 

--- a/src/main/java/com/roamsys/swagger/documentation/ApiSpecBuilder.java
+++ b/src/main/java/com/roamsys/swagger/documentation/ApiSpecBuilder.java
@@ -74,6 +74,17 @@ public class ApiSpecBuilder {
     }
 
     /**
+     * Sets the schemes to be shown and also used for generating test URLs.
+     *
+     * @param schemes the schemes
+     * @return <code>this</code> pointer
+     */
+    public ApiSpecBuilder setSchemes(final List<String> schemes) {
+        apiSpec.schemes = schemes;
+        return this;
+    }
+
+    /**
      * Sets the version to be shown in info block.
      *
      * @param version the version


### PR DESCRIPTION
A scheme different to https (default) can now be used.
Also an optional URL port can be set. 