### PR TITLE
Provide HTTP status and JSON response in case of error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.roamsys.opensource</groupId>
     <artifactId>swaggerapi</artifactId>
     <packaging>jar</packaging>
-    <version>8.0.0-SNAPSHOT</version>
+    <version>9.0.0-SNAPSHOT</version>
     <organization>
         <name>ROAMSYS S.A.</name>
         <url>http://www.roamsys.com</url>

--- a/src/main/java/com/roamsys/swagger/data/SwaggerExceptionHandler.java
+++ b/src/main/java/com/roamsys/swagger/data/SwaggerExceptionHandler.java
@@ -1,5 +1,9 @@
 package com.roamsys.swagger.data;
 
+import com.google.gson.GsonBuilder;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Map;
 import javax.servlet.http.HttpServletResponse;
 
 /**
@@ -10,7 +14,7 @@ import javax.servlet.http.HttpServletResponse;
 public interface SwaggerExceptionHandler {
 
     /**
-     * Default implementation that uses {@link System#err}.
+     * Default implementation that uses {@link System#err}, sets the status and returns error JSON.
      */
     public static final SwaggerExceptionHandler DEFAULT = new SwaggerExceptionHandler() {
 
@@ -19,6 +23,16 @@ public interface SwaggerExceptionHandler {
             System.err.println("Error: " + message + ", status code: " + code);
             if (ex != null) {
                 ex.printStackTrace(System.err);
+            }
+            response.setStatus(code);
+            // write error JSON
+            try {
+                final PrintWriter writer = response.getWriter();
+                response.setContentType(ContentType.JSON_UTF8);
+                new GsonBuilder().create().toJson(Map.of("code", code, "reason", message), writer);
+                writer.flush();
+            } catch (final IOException nested) {
+                nested.printStackTrace(System.err);
             }
         }
     };


### PR DESCRIPTION
The default exception handler now provides the status in HTTP response and also delivers JSON output using:
```
{
  "code": 500,
  "reason": "This should never happen"
 }
```