### PR TITLE
Update version after changing dependency to Apache commons lang3 3.1.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.roamsys.opensource</groupId>
     <artifactId>swaggerapi</artifactId>
     <packaging>jar</packaging>
-    <version>11.0.0-SNAPSHOT</version>
+    <version>12.0.0-SNAPSHOT</version>
     <organization>
         <name>ROAMSYS S.A.</name>
         <url>http://www.roamsys.com</url>


### PR DESCRIPTION
Update to Apache Commons Lang 3 Version 3.1.18 has been done before in https://github.com/ROAMSYS/swaggerapi/pull/65